### PR TITLE
Fix to eliminate errors from W3C validator for datetime format.

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -3,7 +3,7 @@
 {% block content %}
 <article class="post">
     <span class="post-meta">
-        <time datetime="{{ article.locale_date }}">{{ article.locale_date }}</time>
+        <time datetime="{{ article.date|strftime('%Y-%m-%d') }}">{{ article.locale_date }}</time>
         in <a href="{{ SITEURL }}/{{ article.category.url }}/">{{ article.category }}</a>
     </span>
     <h1 class="post-title">

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <article class="post">
         <header class="post-header">
             <span class="post-meta">
-                <time datetime="{{ article.locale_date }}">{{ article.locale_date }}</time>
+                <time datetime="{{ article.date|strftime('%Y-%m-%d') }}">{{ article.locale_date }}</time>
                 in <a href="{{ SITEURL }}/{{ article.category.url }}/">{{ article.category }}</a>
             </span>
             <h2 class="post-title"><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>


### PR DESCRIPTION
Hello - great work on a clean and sharp-looking theme.

I used the theme for my blog and ran it through the [WC3 validator](http://validator.w3.org).  I noticed this error appeared a few times:

```
Bad value <date> for attribute datetime on element time: The literal did not satisfy
the time-datetime format.
```

[Researching a bit further](http://www.w3.org/TR/NOTE-datetime) it seems only certain formats are allowed.

The Pelican docs mention [this method](http://docs.getpelican.com/en/latest/themes.html#date-formatting) of formatting dates.  I applied this only to the `datetime=` portion of the relevant templates to set an accepted format.  The date shown on the blog remains unchanged.

This seemed like a simple way to clean up a group of W3C validation errors without changing (as far as I can tell) how dates appear on the blog.
